### PR TITLE
Boundaries should be closed

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -255,6 +255,9 @@ class Boundary(ElementBase):
     show=_show
     
     def __init__(self, points, layer=None, datatype=None, verbose=False) :
+        if (points[0] != points[-1]).any():
+            points = np.concatenate((points, [points[0]]))
+
         ElementBase.__init__(self, points)
 
         if verbose and 8191 >= self.points.shape[0] > 199:


### PR DESCRIPTION
Please note http://www.rulabinsky.com/cavd/text/chapc.html section C.4

```
 Note that boundaries must be closed explicitly, so the first and last coordinate values must be the same
```

It appears to me that this was not the behavior of gdsCAD currently.
