### PR TITLE
Fix Boundary creation for non-numpy coordinate lists

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -102,7 +102,7 @@ class ElementBase(object):
         return {'color': color}
 
     def __init__(self, points):
-        self._points = np.array(points)
+        self._points = np.asarray(points)
         self._bbox = None
 
     @property
@@ -255,6 +255,7 @@ class Boundary(ElementBase):
     show=_show
     
     def __init__(self, points, layer=None, datatype=None, verbose=False) :
+        points = np.asarray(points)
         if (points[0] != points[-1]).any():
             points = np.concatenate((points, [points[0]]))
 


### PR DESCRIPTION
Commit bf6c05df283 introduced a regression if the point list
is not a numpy array.

One of my users just ran into this issue. Could you release 
this fix in the near future?

Best,
Matthias
