### PR TITLE
FIX: Cast numpy array as list for proper addition

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -180,7 +180,7 @@ class ElementBase(BooleanOps, object):
     def _layer_properties(layer):
         # Default colors from previous versions
         colors = ['k', 'r', 'g', 'b', 'c', 'm', 'y']
-        colors += matplotlib.cm.gist_ncar(np.linspace(0.98, 0, 15))
+        colors += matplotlib.cm.gist_ncar(np.linspace(0.98, 0, 15)).tolist()
         color = colors[layer % len(colors)]
         return {'color': color}
 


### PR DESCRIPTION
This solves the type error raised when trying to plot with matplotlib, detailed in the following StackOverflow question:

http://stackoverflow.com/questions/34264282/typeerror-ufunc-add-did-not-contain-a-loop
