### PR TITLE
fix type mismatch when attempting to plot

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -180,7 +180,7 @@ class ElementBase(BooleanOps, object):
     def _layer_properties(layer):
         # Default colors from previous versions
         colors = ['k', 'r', 'g', 'b', 'c', 'm', 'y']
-        colors += matplotlib.cm.gist_ncar(np.linspace(0.98, 0, 15))
+        colors += list(matplotlib.cm.gist_ncar(np.linspace(0.98, 0, 15)))
         color = colors[layer % len(colors)]
         return {'color': color}
 


### PR DESCRIPTION
The default example on the [homepage](https://pypi.python.org/pypi/gdsCAD) doesn't work on Windows (but probably other platforms as well) with Anaconda installed.

The issue is that a Python list of characters is trying to be appended to a numpy array of `S32`s. We can just convert the array (which is small) into a list and continue going.

The error is below:

```
Documents>python simple_example.py
Writing the following cells
EXAMPLE: Cell ("EXAMPLE", 2 elements, 2 references)
CONT_ALGN: Cell ("CONT_ALGN", 9 elements, 0 references)
TOP: Cell ("TOP", 0 elements, 1 references)
Traceback (most recent call last):
  File "simple_example.py", line 25, in <module>
    layout.show()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 82, in _show
    artists=self.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 1132, in artist
    artists += c.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 1389, in artist
    art+=e.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 1844, in artist
    art=self.ref_cell.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 1389, in artist
    art+=e.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 954, in artist
    art+=p.artist()
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 350, in artist
    return [matplotlib.patches.Polygon(self.points, closed=True, lw=0, **self._layer_properties(self.layer))]
  File "C:\Anaconda2\lib\site-packages\gdscad-0.4.5-py2.7.egg\gdsCAD\core.py", line 105, in _layer_properties
    colors += matplotlib.cm.gist_ncar(np.linspace(0.98, 0, 15))
TypeError: ufunc 'add' did not contain a loop with signature matching types dtype('S32') dtype('S32') dtype('S32')
```
