### PR TITLE
allow for opening of files with corrupt create and/or modify dates.

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -2250,8 +2250,18 @@ def GdsImport(infile, rename={}, layers={}, datatypes={}, verbose=True, unit=1e-
             if verbose==2:
                 print(data[0], end=' ')
         elif 'BGNLIB' == rname:
-            kwargs['created'] = datetime.datetime(*data.tolist()[:6])
-            kwargs['modified'] = datetime.datetime(*data.tolist()[6:])
+            try:
+                kwargs['created'] = datetime.datetime(*data.tolist()[:6])
+            except:
+                warnings.warn("File created date may be corrupt. Resetting to right now.", stacklevel=2)
+                kwargs['created'] = datetime.datetime.today()
+                
+            try:
+                kwargs['modified'] = datetime.datetime(*data.tolist()[6:])
+            except:
+                warnings.warn("File modify date may be corrupt. Resetting to right now.", stacklevel=2)
+                kwargs['modified'] = datetime.datetime.today()
+                
             if verbose==2:
                 print("created %d/%d/%d,%d:%d:%d modified %d/%d/%d,%d:%d:%d" % tuple(data.tolist()), end=' ')
         elif 'LIBNAME' == rname:


### PR DESCRIPTION
Older versions of Layout Editor (i.e. the last free version before a license was required) inject a bogus date and time into the BGNLIB record. This can't be parsed by datetime and so it fails and crashes. This is a workaround to allow for non-parseable entries in that record. If it is unable to parse, it replaces the entry with `datetime.datetime.today()`.

What other programs do with BGNLIB data:

- KLayout offers the option to not write anything to those fields, or to update them at write time. It doesn't attempt to parse them in any way though on read.
- Layout Editor circa 2008/2009 does something strange and stupid on write, and ignores on read.
- gdspy reads in whatever is there, but doesn't try anything fancy with it (i.e. parsing).