### PR TITLE
Small fix to displacement function

### DIFF
--- a/gdsCAD/core.py
+++ b/gdsCAD/core.py
@@ -1745,7 +1745,7 @@ class ReferenceBase:
         :returns: self
 
         """
-        self.origin+=np.array(displacement)
+        self.origin = self.origin + np.array(displacement)
         return self
     
     def rotate(self, angle):


### PR DESCRIPTION
"+=" is a bad way of adding together np.array's of potentially different dtype.  It throws and error when trying to do a displacement with dtype float.  Using a more explicit "+" corrects the bug.